### PR TITLE
Update config.yml

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -32,7 +32,7 @@ collections:
   - name: "blog"
     label: "Frontline News"
     folder: "_posts/"
-    slug: "{{slug}}"
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     preview_path: "news/{{slug}}"
     preview_path_date_field: "date"
     editor:


### PR DESCRIPTION
move slug back to way it was since 2021 articles were not showing up.  Need file names created with {{year}}-{{month}}-{{day}}-{{slug}} format.